### PR TITLE
Add properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,11 +76,13 @@ With Typeson update, empty string components of key paths are now escaped
 - Breaking change: Change from deprecated `@babel/polyfill` to
     `regenerator-runtime` and `core-js-bundle` (may have no impact
     since `@babel/polyfill` included them)
+- Breaking change: Add `stack`, `fileName`, `lineNumber`, `columnNumber`, `cause`, and for `AggregateError`, `errors`
+    and `name` to `errors` (default `name` can be changed after construction);
+    also impacts `builtin`, `universal`, `postmessage`, and `socketio`
 
 - Fix: Use new `Typeson.toStringTag` and `Typeson.hasConstructorOf` to
     get cross-frame/cross-module class detection (replacing `constructor`
     and `instanceof` checks)
-
 - Fix (RegExp): Get `regexp` type to work properly with `multiline`
 - Fix (RegExp): Add `unicode` and `sticky` flag support for cloning
 - Fix (Date): Support invalid dates (with `NaN` value)
@@ -120,6 +122,10 @@ With Typeson update, empty string components of key paths are now escaped
     to allow for non-plain user objects to be cloned; add test
 - Enhancement: Add `nonbuiltin-ignore` type to roughly detect non-builtin
     objects and avoid adding them as properties
+- Enhancement: Add `stack`, `fileName`, `lineNumber`, `columnNumber`,
+    `cause`, and `errors` (for `AggregateError`)
+    to `error` (changes representation, but less likely than `errors` to be
+    breaking); fixes #10
 - Enhancement (minor): Check `typeof` for functions in SCA since can avoid
     false positives
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,8 @@ With Typeson update, empty string components of key paths are now escaped
     to allow for non-plain user objects to be cloned; add test
 - Enhancement: Add `nonbuiltin-ignore` type to roughly detect non-builtin
     objects and avoid adding them as properties
+- Enhancement: Add `error` and `errors` to SCA
+- Enhancement: Support `AggregateError` with `errors.js`
 - Enhancement: Add `stack`, `fileName`, `lineNumber`, `columnNumber`,
     `cause`, and `errors` (for `AggregateError`)
     to `error` (changes representation, but less likely than `errors` to be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeson-registry",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "The type registry for typeson",
   "author": "dfahlander",
   "contributors": [

--- a/presets/structured-cloning.js
+++ b/presets/structured-cloning.js
@@ -9,6 +9,8 @@ import date from '../types/date.js';
 import regexp from '../types/regexp.js';
 import map from '../types/map.js';
 import set from '../types/set.js';
+import error from '../types/error.js';
+import errors from '../types/errors.js';
 import arraybuffer from '../types/arraybuffer.js';
 import typedArrays from '../types/typed-arrays.js';
 import dataview from '../types/dataview.js';
@@ -39,7 +41,9 @@ const expObj = [
     imagebitmap, // Async return
     file,
     filelist,
-    blob
+    blob,
+    error,
+    errors
 ].concat(
     // ES2015 (ES6)
     /* c8 ignore next */

--- a/types/error.js
+++ b/types/error.js
@@ -3,12 +3,21 @@ import {toStringTag} from 'typeson';
 const error = {
     error: {
         test (x) { return toStringTag(x) === 'Error'; },
-        replace ({name, message}) {
-            return {name, message};
+        replace ({
+            name, message, cause, stack, fileName, lineNumber, columnNumber
+        }) {
+            return {
+                name, message, cause, stack, fileName, lineNumber, columnNumber
+            };
         },
-        revive ({name, message}) {
-            const e = new Error(message);
-            e.name = name;
+        revive (obj) {
+            const e = new Error(obj.message);
+            [
+                'name', 'cause', 'stack', 'fileName', 'lineNumber',
+                'columnNumber'
+            ].forEach((prop) => {
+                e[prop] = obj[prop];
+            });
             return e;
         }
     }

--- a/types/errors.js
+++ b/types/errors.js
@@ -9,6 +9,11 @@ const errors = {};
     TypeError, RangeError, SyntaxError, ReferenceError, EvalError, URIError
 ].forEach((error) => create(error));
 
+/* c8 ignore next 3 */
+if (typeof AggregateError !== 'undefined') {
+    create(AggregateError);
+}
+
 /* c8 ignore next 2 */
 // @ts-ignore Non-standard
 typeof InternalError === 'function' && create(InternalError);
@@ -17,15 +22,40 @@ typeof InternalError === 'function' && create(InternalError);
  * Comprises all built-in errors.
  * @param {
  *   TypeError|RangeError|SyntaxError|ReferenceError|EvalError|URIError|
- *   InternalError
+ *   AggregateError|InternalError
  * } Ctor
  * @returns {void}
  */
 function create (Ctor) {
     errors[Ctor.name.toLowerCase()] = {
         test (x) { return hasConstructorOf(x, Ctor); },
-        replace (e) { return e.message; },
-        revive (message) { return new Ctor(message); }
+        replace ({
+            name, message, cause, stack, fileName,
+            lineNumber, columnNumber, errors: errs
+        }) {
+            return {
+                name, message, cause, stack, fileName,
+                lineNumber, columnNumber, errors: errs
+            };
+        },
+        revive (obj) {
+            const isAggregateError = typeof AggregateError !== 'undefined' &&
+                Ctor === AggregateError;
+            const e = isAggregateError
+                ? new Ctor(obj.errors, obj.message)
+                : new Ctor(obj.message);
+            [
+                'name', 'cause', 'stack', 'fileName', 'lineNumber',
+                'columnNumber'
+            ].forEach((prop) => {
+                e[prop] = obj[prop];
+            });
+            /* c8 ignore next 6 */
+            if (isAggregateError) {
+                e.errors = obj.errors;
+            }
+            return e;
+        }
     };
 }
 


### PR DESCRIPTION
- Breaking change: Add `stack`, `fileName`, `lineNumber`, and `columnNumber`
    and `name` to `errors` (default `name` can be changed after construction);
    also impacts `builtin`, `universal`, `postmessage`, and `socketio`
- Enhancement: Add `stack`, `fileName`, `lineNumber`, and `columnNumber`
    to `error` (changes representation, but less likely than `errors` to be
    breaking); fixes #10
- Enhancement: Add `AggregateError` to `errors.js`