### PR TITLE
fix: global fetching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 os: linux
-dist: xenial
+dist: focal
 
 node_js:
+  - "18"
   - "16"
   - "14.17.0"
-  - "12.22.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "homepage": "https://github.com/dfahlander/typeson-registry#readme",
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    "node": "^14.17.0 || >=16.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/types/errors.js
+++ b/types/errors.js
@@ -1,28 +1,32 @@
+/* globals InternalError */
 /* eslint-env browser, node */
 import {hasConstructorOf} from 'typeson';
 
-/* c8 ignore next */
-const _global = typeof self === 'undefined' ? global : self;
-
 const errors = {};
-// Comprises all built-in errors.
+
+// JS standard
 [
-    'TypeError',
-    'RangeError',
-    'SyntaxError',
-    'ReferenceError',
-    'EvalError',
-    'URIError',
-    'InternalError' // non-standard
-].forEach((errName) => {
-    const Cnstrctr = _global[errName];
-    if (Cnstrctr) {
-        errors[errName.toLowerCase()] = {
-            test (x) { return hasConstructorOf(x, Cnstrctr); },
-            replace (e) { return e.message; },
-            revive (message) { return new Cnstrctr(message); }
-        };
-    }
-});
+    TypeError, RangeError, SyntaxError, ReferenceError, EvalError, URIError
+].forEach((error) => create(error));
+
+/* c8 ignore next 2 */
+// @ts-ignore Non-standard
+typeof InternalError === 'function' && create(InternalError);
+
+/**
+ * Comprises all built-in errors.
+ * @param {
+ *   TypeError|RangeError|SyntaxError|ReferenceError|EvalError|URIError|
+ *   InternalError
+ * } Ctor
+ * @returns {void}
+ */
+function create (Ctor) {
+    errors[Ctor.name.toLowerCase()] = {
+        test (x) { return hasConstructorOf(x, Ctor); },
+        replace (e) { return e.message; },
+        revive (message) { return new Ctor(message); }
+    };
+}
 
 export default errors;

--- a/types/typed-arrays-socketio.js
+++ b/types/typed-arrays-socketio.js
@@ -1,30 +1,20 @@
 /* eslint-env browser, node */
 import {toStringTag} from 'typeson';
 
-/* c8 ignore next */
-const _global = typeof self === 'undefined' ? global : self;
-
 // Support all kinds of typed arrays (views of ArrayBuffers)
 const typedArraysSocketIO = {};
-[
-    'Int8Array',
-    'Uint8Array',
-    'Uint8ClampedArray',
-    'Int16Array',
-    'Uint16Array',
-    'Int32Array',
-    'Uint32Array',
-    'Float32Array',
-    'Float64Array'
-].forEach(function (typeName) {
-    const arrType = typeName;
-    const TypedArray = _global[typeName];
-    /* c8 ignore next 3 */
-    if (!TypedArray) {
-        return;
-    }
+
+/**
+ * @param {
+ *   Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|
+ *   Uint32Array|Float32Array|Float64Array
+ * } TypedArray
+ * @returns {void}
+ */
+function create (TypedArray) {
+    const typeName = TypedArray.name;
     typedArraysSocketIO[typeName.toLowerCase()] = {
-        test (x) { return toStringTag(x) === arrType; },
+        test (x) { return toStringTag(x) === typeName; },
         replace (a) {
             return (a.byteOffset === 0 &&
                 a.byteLength === a.buffer.byteLength
@@ -47,6 +37,23 @@ const typedArraysSocketIO = {};
                 : buf;
         }
     };
-});
+}
+
+if (typeof Int8Array === 'function') {
+    // Those constructors are added in ES6 as a group.
+    // If we have Int8Array, we can assume the rest also exists.
+
+    [
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array
+    ].forEach((TypedArray) => create(TypedArray));
+}
 
 export default typedArraysSocketIO;

--- a/types/typed-arrays.js
+++ b/types/typed-arrays.js
@@ -2,29 +2,19 @@
 import {toStringTag} from 'typeson';
 import {encode, decode} from 'base64-arraybuffer-es6';
 
-/* c8 ignore next */
-const _global = typeof self === 'undefined' ? global : self;
-
 const typedArrays = {};
-[
-    'Int8Array',
-    'Uint8Array',
-    'Uint8ClampedArray',
-    'Int16Array',
-    'Uint16Array',
-    'Int32Array',
-    'Uint32Array',
-    'Float32Array',
-    'Float64Array'
-].forEach(function (typeName) {
-    const arrType = typeName;
-    const TypedArray = _global[arrType];
-    /* c8 ignore next 3 */
-    if (!TypedArray) {
-        return;
-    }
+
+/**
+ * @param {
+ *   Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|
+ *   Uint32Array|Float32Array|Float64Array
+ * } TypedArray
+ * @returns {void}
+ */
+function create (TypedArray) {
+    const typeName = TypedArray.name;
     typedArrays[typeName.toLowerCase()] = {
-        test (x) { return toStringTag(x) === arrType; },
+        test (x) { return toStringTag(x) === typeName; },
         replace ({buffer, byteOffset, length: l}, stateObj) {
             if (!stateObj.buffers) {
                 stateObj.buffers = [];
@@ -55,6 +45,22 @@ const typedArrays = {};
             return new TypedArray(buffer, byteOffset, len);
         }
     };
-});
+}
+
+if (typeof Int8Array === 'function') {
+    // Those constructors are added in ES6 as a group.
+    // If we have Int8Array, we can assume the rest also exists.
+    [
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array
+    ].forEach((TypedArray) => create(TypedArray));
+}
 
 export default typedArrays;


### PR DESCRIPTION
Hi! I want to fix an edge case for global object fetching.

Our environment is special (if you're curious, it is in the content script of Firefox Web Extension), it has a global object "globalThis" which is defined in the JavaScript standard, and it also has a "window" and "self" objects. But they **are not equal**. Which means:

```js
globalThis === window // false
globaThis.Uint8Array === window.Uint8Array // false
Uint8Array === globalThis.Uint8Array // true
new self.Uint8Array() // Throws: SecurityError
```

![image](https://user-images.githubusercontent.com/5390719/164959215-bb564979-9b4a-44a5-96f7-d9ec047b9fbf.png)

I made a change on this library to let it direct access those properties instead of doing a runtime lookup on the "self" object.