### PR TITLE
feat:  add support for `maxByteLength`

### DIFF
--- a/browser-test/index.html
+++ b/browser-test/index.html
@@ -28,7 +28,8 @@
                     "base64-arraybuffer-es6": "../node_modules/base64-arraybuffer-es6/dist/base64-arraybuffer-es.js",
                     "/test/helpers/test-environment.js": "./test-environment.js",
                     "/test/helpers/io.js": "./io.js",
-                    "socket.io-client": "./socket.io-client.js"
+                    "socket.io-client": "./socket.io-client.js",
+                    "semver": "./semver-stub.js"
                 }
             }
         </script>

--- a/browser-test/semver-stub.js
+++ b/browser-test/semver-stub.js
@@ -1,0 +1,7 @@
+const semver = {
+    satisfies () {
+        return true;
+    }
+};
+
+export default semver;

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/chai": "^4.3.11",
     "@types/jsdom": "^21.1.6",
     "@types/mocha": "^10.0.6",
+    "@types/semver": "^7.5.6",
     "@types/whatwg-url": "^11.0.3",
     "c8": "^8.0.1",
     "canvas": "^2.11.2",
@@ -122,6 +123,7 @@
     "mocha": "^10.2.0",
     "open-cli": "^7.2.0",
     "rollup": "^4.9.0",
+    "semver": "^7.5.4",
     "socket.io": "^4.7.2",
     "socket.io-client": "^4.7.2",
     "typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ devDependencies:
   '@types/mocha':
     specifier: ^10.0.6
     version: 10.0.6
+  '@types/semver':
+    specifier: ^7.5.6
+    version: 7.5.6
   '@types/whatwg-url':
     specifier: ^11.0.3
     version: 11.0.3
@@ -133,6 +136,9 @@ devDependencies:
   rollup:
     specifier: ^4.9.0
     version: 4.9.0
+  semver:
+    specifier: ^7.5.4
+    version: 7.5.4
   socket.io:
     specifier: ^4.7.2
     version: 4.7.2
@@ -1918,8 +1924,8 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
-  /@types/semver@7.5.4:
-    resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
   /@types/tough-cookie@4.0.2:
@@ -2002,7 +2008,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.4
+      '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.10.0
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.3)

--- a/types/arraybuffer.js
+++ b/types/arraybuffer.js
@@ -23,7 +23,10 @@ const arraybuffer = {
                 return {index};
             }
             stateObj.buffers.push(b);
-            return encode(b);
+            return {
+                s: encode(b),
+                maxByteLength: b.maxByteLength
+            };
         },
         revive (
             b64,
@@ -36,7 +39,7 @@ const arraybuffer = {
             if (!stateObj.buffers) {
                 stateObj.buffers = [];
             }
-            if (typeof b64 === 'object') {
+            if (Object.hasOwn(b64, 'index')) {
                 return stateObj.buffers[
                     /**
                      * @type {{index: import('typeson').Integer}}
@@ -44,7 +47,10 @@ const arraybuffer = {
                     (b64).index
                 ];
             }
-            const buffer = decode(/** @type {string} */ (b64));
+            const buffer = decode(
+                /** @type {string} */ (b64.s),
+                {maxByteLength: b64.maxByteLength}
+            );
             stateObj.buffers.push(buffer);
             return buffer;
         }

--- a/types/dataview.js
+++ b/types/dataview.js
@@ -26,6 +26,7 @@ const dataview = {
             stateObj.buffers.push(buffer);
             return {
                 encoded: encode(buffer),
+                maxByteLength: buffer.maxByteLength,
                 byteOffset,
                 byteLength
             };
@@ -42,12 +43,20 @@ const dataview = {
             if (!stateObj.buffers) {
                 stateObj.buffers = [];
             }
-            const {byteOffset, byteLength, encoded, index} = b64Obj;
+            const {
+                byteOffset, byteLength, encoded, index, maxByteLength
+            } = b64Obj;
             let buffer;
             if ('index' in b64Obj) {
                 buffer = stateObj.buffers[index];
             } else {
-                buffer = decode(encoded);
+                buffer = decode(
+                    encoded,
+                    /* c8 ignore next 3 -- Depends on Node version */
+                    maxByteLength === undefined
+                        ? maxByteLength
+                        : {maxByteLength}
+                );
                 stateObj.buffers.push(buffer);
             }
             return new DataView(buffer, byteOffset, byteLength);

--- a/types/typed-arrays.js
+++ b/types/typed-arrays.js
@@ -44,6 +44,7 @@ function create (TypedArray) {
             }
             stateObj.buffers.push(buffer);
             return {
+                maxByteLength: buffer.maxByteLength,
                 encoded: encode(buffer),
                 byteOffset,
                 length: l
@@ -61,12 +62,20 @@ function create (TypedArray) {
             if (!stateObj.buffers) {
                 stateObj.buffers = [];
             }
-            const {byteOffset, length: len, encoded, index} = b64Obj;
+            const {
+                byteOffset, length: len, encoded, index, maxByteLength
+            } = b64Obj;
             let buffer;
             if ('index' in b64Obj) {
                 buffer = stateObj.buffers[index];
             } else {
-                buffer = decode(encoded);
+                buffer = decode(
+                    encoded,
+                    /* c8 ignore next 3 -- Depends on Node version */
+                    maxByteLength === undefined
+                        ? undefined
+                        : {maxByteLength}
+                );
                 stateObj.buffers.push(buffer);
             }
             return new TypedArray(buffer, byteOffset, len);


### PR DESCRIPTION
feat:  add support for `maxByteLength`

BREAKING CHANGE:

Encodes array buffers as objects rather than strings in order to add any metadata

Wanted to give you a heads up, @dfahlander , as it modifies long-standing types like arraybuffer (to accommodate the new `maxByteLength` option)...

The `semver` check is because this option is only available in Node 20+ (and not yet in Firefox, I might add).